### PR TITLE
adds option for custom child selector

### DIFF
--- a/src/pageable.js
+++ b/src/pageable.js
@@ -134,6 +134,7 @@
             freeScroll: false,
             slideshow: false,
             infinite: false,
+            childSelector: '[data-anchor]',
             events: {
                 wheel: true,
                 mouse: true,
@@ -163,12 +164,12 @@
             this.container.appendChild(frag);
         }
 
-        // search for child nodes with the [data-anchor] attribute
-        this.pages = this.container.querySelectorAll("[data-anchor]");
+        // search for child nodes using the child selector
+        this.pages = this.container.querySelectorAll(this.config.childSelector);
 
         // none found
         if (!this.pages.length) {
-            return console.error("Pageable:", "No child nodes with the [data-anchor] attribute could be found.");
+            return console.error("Pageable:", "No child nodes matching the selector " + this.config.childSelector + " could be found.");
         }
 
         this.horizontal = this.config.orientation === "horizontal";
@@ -724,7 +725,7 @@
         }
 
         // prevent firing if not on a page
-        if (!evt.target.closest("[data-anchor]")) {
+        if (!evt.target.closest(this.childSelector)) {
             return false;
         }
 

--- a/src/pageable.js
+++ b/src/pageable.js
@@ -177,7 +177,11 @@
         this.anchors = [];
 
         this.pages.forEach(function(page, i) {
-            var clean = page.dataset.anchor.replace(/\s+/, "-").toLowerCase();
+            if (typeof page.dataset.anchor !== 'undefined') {
+                var clean = page.dataset.anchor.replace(/\s+/, "-").toLowerCase();
+            } else {
+                var clean = page.classList.value.replace(/\s+/, "-").toLowerCase();
+            }
             if (page.id !== clean) {
                 page.id = clean;
             }


### PR DESCRIPTION
Currently the child containers are all required to have a data-anchor attribute. I thought it would be useful to be able to manually override that [data-anchor] selector with a selector of my choosing.